### PR TITLE
expose kubeconfig hash

### DIFF
--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -83,6 +83,10 @@ module Kubeclient
       Context.new(cluster['server'], @kcfg['apiVersion'], ssl_options, auth_options, namespace)
     end
 
+    def kube_config
+      @kcfg
+    end
+
     private
 
     def allow_external_lookups?


### PR DESCRIPTION
Sometimes you need to access the raw kube_config hash. This PR adds a method to do so