### PR TITLE
bearer_token_file: load inline

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -706,10 +706,21 @@ module Kubeclient
     end
 
     def http_options(uri)
+      bearer_token = nil
+      if @auth_options[:bearer_token_file]
+        bearer_token_file = @auth_options[:bearer_token_file]
+        if File.file?(bearer_token_file) and File.readable?(bearer_token_file)
+          token = File.read(bearer_token_file).chomp
+          bearer_token = "Bearer #{token}"
+        end
+      elsif @auth_options[:bearer_token]
+        bearer_token = "Bearer #{@auth_options[:bearer_token]}"
+      end
 
       options = {
         basic_auth_user: @auth_options[:username],
         basic_auth_password: @auth_options[:password],
+        authorization: bearer_token,
         headers: @headers,
         http_proxy_uri: @http_proxy_uri,
         http_max_redirects: http_max_redirects

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -354,7 +354,9 @@ module Kubeclient
         if @auth_options[:username]
           connection.request(:basic_auth, @auth_options[:username], @auth_options[:password])
         elsif @auth_options[:bearer_token_file]
-          connection.request(:authorization, 'Bearer', -> { File.read(@auth_options[:bearer_token_file]).chomp })
+          connection.request(:authorization, 'Bearer', lambda do
+            File.read(@auth_options[:bearer_token_file]).chomp
+          end)
         elsif @auth_options[:bearer_token]
           connection.request(:authorization, 'Bearer', @auth_options[:bearer_token])
         end
@@ -709,7 +711,7 @@ module Kubeclient
       bearer_token = nil
       if @auth_options[:bearer_token_file]
         bearer_token_file = @auth_options[:bearer_token_file]
-        if File.file?(bearer_token_file) and File.readable?(bearer_token_file)
+        if File.file?(bearer_token_file) && File.readable?(bearer_token_file)
           token = File.read(bearer_token_file).chomp
           bearer_token = "Bearer #{token}"
         end

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -353,6 +353,8 @@ module Kubeclient
       Faraday.new(url, options) do |connection|
         if @auth_options[:username]
           connection.request(:basic_auth, @auth_options[:username], @auth_options[:password])
+        elsif @auth_options[:bearer_token_file]
+          connection.request(:authorization, 'Bearer', -> { File.read(@auth_options[:bearer_token_file]).chomp })
         elsif @auth_options[:bearer_token]
           connection.request(:authorization, 'Bearer', @auth_options[:bearer_token])
         end
@@ -366,7 +368,6 @@ module Kubeclient
     end
 
     def faraday_client
-      refresh_bearer_token_from_file
       @faraday_client ||= create_faraday_client
     end
 
@@ -705,7 +706,6 @@ module Kubeclient
     end
 
     def http_options(uri)
-      refresh_bearer_token_from_file
 
       options = {
         basic_auth_user: @auth_options[:username],
@@ -728,11 +728,6 @@ module Kubeclient
       end
 
       options.merge(@socket_options)
-    end
-
-    def refresh_bearer_token_from_file
-      return unless (file = @auth_options[:bearer_token_file])
-      @auth_options[:bearer_token] = File.read(file).chomp
     end
 
     def json_headers

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.9.2'
+  VERSION = '4.9.3'
 end

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.9.3'
+  VERSION = '4.9.2'
 end

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -65,6 +65,10 @@ module Kubeclient
           )
         end
 
+        if @http_options[:authorization]
+          client = client.auth(@http_options[:authorization])
+        end
+
         client
       end
 


### PR DESCRIPTION
simplify loading the bearer token from file, to just reading it inline. The previous approach with refreshing the token from file from various points, seems to have missed something - we were still flagged by the audit logging on our k8s clusters.