### PR TITLE
verify_ssl should be converted to a bool for faraday

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -345,7 +345,8 @@ module Kubeclient
           cert_store: @ssl_options[:cert_store],
           client_cert: @ssl_options[:client_cert],
           client_key: @ssl_options[:client_key],
-          verify: @ssl_options[:verify_ssl]
+          verify: @ssl_options[:verify_ssl] != OpenSSL::SSL::VERIFY_NONE,
+          verify_mode: @ssl_options[:verify_ssl]
         }
       }
 


### PR DESCRIPTION
in faraday they support `verify` it should be a bool, it also supports
verify_mode which is defined here
https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html

currently to disable certificate verification explicitly we would pass, `OpenSSL::SSL::VERIFY_NONE == 0` so this results in verification being turned on.
```
ssl_options = { verify_ssl: OpenSSL::SSL::VERIFY_NONE }
client = Kubeclient::Client.new(
  'https://localhost:8443/api', 'v1', ssl_options: ssl_options
)
```

Faraday configuration is described here https://github.com/lostisland/faraday/blob/21ac595919b0372b41386ae00640e16f73a20d31/lib/faraday/options/ssl_options.rb#L7