### PR TITLE
[v4.y] Ensure VCR doesn't leak into other tests

### DIFF
--- a/test/test_guestbook_go.rb
+++ b/test/test_guestbook_go.rb
@@ -41,6 +41,8 @@ class CreateGuestbookGo < MiniTest::Test
 
       client.delete_namespace(testing_ns.metadata.name)
     end
+  ensure
+    VCR.turn_off!
   end
 
   def delete_namespace(client, namespace_name)


### PR DESCRIPTION
VCR was interfering with my attempts to add tests connecting to a real cluster (#545), despite `WebMock.enable_net_connect!`.
What's worse, it depended on order that tests executed (errored iff VCR run test run first).

[This won't be needed on master, we dropped the VCR test in #495.]

cc @grosser