### PR TITLE
[v4.y] Test on Ruby 3.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', 'truffleruby-head' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head' ]
         os: ['ubuntu-latest', 'macos-latest']
         task: [test]
         include:

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'googleauth', '~> 0.5.1'
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
+  spec.add_development_dependency 'net-smtp'
 
   spec.add_dependency 'jsonpath', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'


### PR DESCRIPTION
stealing @kjetijor's commit from #537.
Is net-smtp all we need to fix the 3.1 tests #543 ? :tada:
I'm still not sure where `net/smtp` actually gets `require`-d, but pretty certain it's not in kubeclient itself so a dev dependency sounds right.