### PR TITLE
Test on Ruby 3.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: ${{ contains(matrix.ruby, '-head') }}
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', 'ruby-head', 'truffleruby-head']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head']
         os: ['ubuntu-latest', 'macos-latest']
         task: [test]
         include:

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'googleauth', '~> 0.5'
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
+  spec.add_development_dependency 'net-smtp'
 
   spec.add_dependency 'faraday', '~> 1.1'
   spec.add_dependency 'faraday_middleware', '~> 1.0'


### PR DESCRIPTION
stealing @kjetijor's commit 0781a9dd8801227eca1094fbdb2e92e31b74f070 from https://github.com/ManageIQ/kubeclient/pull/537 (again, this time on master branch)
I'm still not sure where net/smtp actually gets require-d, but pretty certain it's not in kubeclient itself so a dev dependency sounds right.

Fixes #543 :tada: