### PR TITLE
CI: run on windows?

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,7 +37,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false # disable running 'bundle install' and caching installed gems see https://github.com/httprb/http/issues/572
-    - run: gem install rake bundler
     - run: bundle install
     - run: ${{ matrix.os_and_command.command }}
     timeout-minutes: 10

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,7 +16,9 @@ jobs:
       matrix:
         ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head' ]
         os_and_command:
-        - os: 'macos-latest'
+        - os: macos-latest
+          command: 'env TESTOPTS="--verbose" bundle exec rake test'
+        - os: windows-latest
           command: 'env TESTOPTS="--verbose" bundle exec rake test'
         - os: ubuntu-latest
           # Sometimes minitest starts and then just hangs printing nothing.

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'net-smtp'
+  # needed on Windows, at least for openid_connect
+  spec.add_development_dependency 'tzinfo-data'
 
   spec.add_dependency 'jsonpath', '~> 1.0'
   spec.add_dependency 'rest-client', '~> 2.0'


### PR DESCRIPTION
Don't know if it works, let's try :-)

'windows-latest` currently means Windows Server 2022
(https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/)
