### PR TITLE
[v4.y] SECURITY: Kubeclient::Config: return ssl_options[:verify_ssl] correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,30 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 
-## Unreleased 4.9.z
+## 4.9.3 — 2021-03-23
 
 ### Fixed
+
+- VULNERABILITY FIX: Previously, whenever kubeconfig did not define custom CA
+  (normal situation for production clusters with public domain and certificate!),
+  `Config` was returning ssl_options[:verify_ssl] hard-coded to `VERIFY_NONE` :-(
+
+  Assuming you passed those ssl_options to Kubeclient::Client, this means that
+  instead of checking server's certificate against your system CA store,
+  it would accept ANY certificate, allowing easy man-in-the middle attacks.
+
+  This is especially dangerous with user/password or token credentials
+  because MITM attacker could simply steal those credentials to the cluster
+  and do anything you could do on the cluster.
+
+  This was broken IN ALL RELEASES MADE BEFORE 2022, ever since
+  [`Kubeclient::Config` was created](https://github.com/ManageIQ/kubeclient/pull/127/files#diff-32e70f2f6781a9e9c7b83ae5e7eaf5ffd068a05649077fa38f6789e72f3de837R41-R48).
+
+- Bug fix: kubeconfig `insecure-skip-tls-verify` field was ignored.
+  When kubeconfig did define custom CA, `Config` was returning hard-coded `VERIFY_PEER`.
+
+  Now we honor it, return `VERIFY_NONE` iff kubeconfig has explicit
+  `insecure-skip-tls-verify: true`, otherwise `VERIFY_PEER`.
 
 - `Config`: fixed parsing of `certificate-authority` file containing concatenation of
   several certificates.  Previously, server's cert was checked against only first CA cert,
@@ -18,6 +39,9 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
   - Still broken (#460): inline `certificate-authority-data` is still parsed using `add_cert`
     method that handles only one cert.
+
+These don't affect code that supplies `Client` parameters directly,
+only code that uses `Config`.
 
 ## 4.9.2 — 2021-05-30
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ The client supports GET, POST, PUT, DELETE on all the entities available in kube
 The client currently supports Kubernetes REST api version v1.
 To learn more about groups and versions in kubernetes refer to [k8s docs](https://kubernetes.io/docs/api/)
 
+## VULNERABILITY❗
+
+If you use `Kubeclient::Config`, all gem versions released before 2022 could return incorrect `ssl_options[:verify_ssl]`,
+endangering your connection and cluster credentials.
+See [latest CHANGELOG.md](https://github.com/ManageIQ/kubeclient/blob/master/CHANGELOG.md) for details and which versions got a fix.
+Open an issue if you want a backport to another version.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -57,13 +57,16 @@ module Kubeclient
 
       ssl_options = {}
 
+      ssl_options[:verify_ssl] = if cluster['insecure-skip-tls-verify'] == true
+                                   OpenSSL::SSL::VERIFY_NONE
+                                 else
+                                   OpenSSL::SSL::VERIFY_PEER
+                                 end
+
       if cluster_ca_data?(cluster)
         cert_store = OpenSSL::X509::Store.new
         populate_cert_store_from_cluster_ca_data(cluster, cert_store)
-        ssl_options[:verify_ssl] = OpenSSL::SSL::VERIFY_PEER
         ssl_options[:cert_store] = cert_store
-      else
-        ssl_options[:verify_ssl] = OpenSSL::SSL::VERIFY_NONE
       end
 
       unless client_cert_data.nil?

--- a/test/config/execauth.kubeconfig
+++ b/test/config/execauth.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:6443
-    insecure-skip-tls-verify: true
   name: localhost:6443
 contexts:
 - context:

--- a/test/config/external-without-ca.kubeconfig
+++ b/test/config/external-without-ca.kubeconfig
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    # Not defining custom `certificate-authority`.
+    # Without it, the localhost cert should be rejected.
+    server: https://localhost:6443
+  name: local
+contexts:
+- context:
+    cluster: local
+    namespace: default
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate: external-cert.pem
+    client-key: external-key.rsa

--- a/test/config/gcpauth.kubeconfig
+++ b/test/config/gcpauth.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:8443
-    insecure-skip-tls-verify: true
   name: localhost:8443
 contexts:
 - context:

--- a/test/config/gcpcmdauth.kubeconfig
+++ b/test/config/gcpcmdauth.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:8443
-    insecure-skip-tls-verify: true
   name: localhost:8443
 contexts:
 - context:

--- a/test/config/insecure-custom-ca.kubeconfig
+++ b/test/config/insecure-custom-ca.kubeconfig
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    # This is a silly configuration, skip-tls-verify makes CA data useless, but testing for completeness.
+    certificate-authority: external-ca.pem
+    server: https://localhost:6443
+    insecure-skip-tls-verify: true
+  name: local
+contexts:
+- context:
+    cluster: local
+    namespace: default
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate: external-cert.pem
+    client-key: external-key.rsa

--- a/test/config/insecure.kubeconfig
+++ b/test/config/insecure.kubeconfig
@@ -1,0 +1,25 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+    insecure-skip-tls-verify: true
+  name: local
+contexts:
+- context:
+    cluster: local
+    namespace: default
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    # Providing ANY credentials in `insecure-skip-tls-verify` mode is unwise due to MITM risk.
+    # At least client certs are not as catastrophic as bearer tokens.
+    #
+    # This combination of insecure + client certs was once broken in kubernetes but
+    # is meaningful since 2015 (https://github.com/kubernetes/kubernetes/pull/15430).
+    client-certificate: external-cert.pem
+    client-key: external-key.rsa

--- a/test/config/nouser.kubeconfig
+++ b/test/config/nouser.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:6443
-    insecure-skip-tls-verify: true
   name: localhost:6443
 contexts:
 - context:

--- a/test/config/oidcauth.kubeconfig
+++ b/test/config/oidcauth.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:8443
-    insecure-skip-tls-verify: true
   name: localhost:8443
 contexts:
 - context:

--- a/test/config/secure-without-ca.kubeconfig
+++ b/test/config/secure-without-ca.kubeconfig
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    # Not defining custom `certificate-authority`.
+    # Without it, the localhost cert should be rejected.
+    server: https://localhost:6443
+    insecure-skip-tls-verify: false  # Same as external-without-ca.kubeconfig but with explicit false here.
+  name: local
+contexts:
+- context:
+    cluster: local
+    namespace: default
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate: external-cert.pem
+    client-key: external-key.rsa

--- a/test/config/secure.kubeconfig
+++ b/test/config/secure.kubeconfig
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: external-ca.pem
+    server: https://localhost:6443
+    insecure-skip-tls-verify: false  # Same as external.kubeconfig but with explicit false here.
+  name: local
+contexts:
+- context:
+    cluster: local
+    namespace: default
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    client-certificate: external-cert.pem
+    client-key: external-key.rsa

--- a/test/config/userauth.kubeconfig
+++ b/test/config/userauth.kubeconfig
@@ -2,7 +2,6 @@ apiVersion: v1
 clusters:
 - cluster:
     server: https://localhost:6443
-    insecure-skip-tls-verify: true
   name: localhost:6443
 contexts:
 - context:


### PR DESCRIPTION
Fixing #554 and #555, this branch will be released as 4.9.3.

Split into fix/unit tests/real-cluster integration tests commits for ease of backporting.
(the first fix commit itself is branched directly from ancient #127 that introduced the issue, hence the later merge commits)

cc @grosser @agrare @jperville @lnacshonredhat
