### PR TITLE
fixup CHANGELOG and README about #554, #555

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
   This was broken IN ALL RELEASES MADE BEFORE 2022, ever since
   [`Kubeclient::Config` was created](https://github.com/ManageIQ/kubeclient/pull/127/files#diff-32e70f2f6781a9e9c7b83ae5e7eaf5ffd068a05649077fa38f6789e72f3de837R41-R48).
 
+  [#554](https://github.com/ManageIQ/kubeclient/issues/554).
+
 - Bug fix: kubeconfig `insecure-skip-tls-verify` field was ignored.
   When kubeconfig did define custom CA, `Config` was returning hard-coded `VERIFY_PEER`.
 
   Now we honor it, return `VERIFY_NONE` iff kubeconfig has explicit
   `insecure-skip-tls-verify: true`, otherwise `VERIFY_PEER`.
+
+  [#555](https://github.com/ManageIQ/kubeclient/issues/555).
 
 - `Config`: fixed parsing of `certificate-authority` file containing concatenation of
   several certificates.  Previously, server's cert was checked against only first CA cert,

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ To learn more about groups and versions in kubernetes refer to [k8s docs](https:
 
 If you use `Kubeclient::Config`, all gem versions released before 2022 could return incorrect `ssl_options[:verify_ssl]`,
 endangering your connection and cluster credentials.
-See [latest CHANGELOG.md](https://github.com/ManageIQ/kubeclient/blob/master/CHANGELOG.md) for details and which versions got a fix.
-Open an issue if you want a backport to another version.
+See https://github.com/ManageIQ/kubeclient/issues/554 for details and which versions got a fix.
 
 ## Installation
 


### PR DESCRIPTION
Tiny followup to https://github.com/ManageIQ/kubeclient/pull/556.
Sorry for noise, had these locally but forgot to push before merging :man_facepalming: 

If I start backporting, CHANGELOG.md on master branch might not always be updated with all backports (it SHOULD, but it will require separate merges to master).
So I prefer pointing to the vulnerability issue as the "source of truth".
Also, security impact will be better discussed on the issue.