### PR TITLE
[4.y] Refresh token on every request

### DIFF
--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -79,6 +79,7 @@ module Kubeclient
       end
 
       def build_client_options
+        @http_options[:headers][:Authorization] = "Bearer #{File.read(@http_options[:bearer_token_file])}" if @http_options[:bearer_token_file]
         client_options = {
           headers: @http_options[:headers],
           proxy: using_proxy

--- a/test/test_google_application_default_credentials.rb
+++ b/test/test_google_application_default_credentials.rb
@@ -1,15 +1,15 @@
-require_relative 'test_helper'
-require 'googleauth'
+# require_relative 'test_helper'
+# require 'googleauth'
 
 # Unit tests for the ApplicationDefaultCredentials token provider
-class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
-  def test_token
-    auth = Minitest::Mock.new
-    auth.expect(:apply, nil, [{}])
-    auth.expect(:access_token, 'valid_token')
+# class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
+#   def test_token
+#     auth = Minitest::Mock.new
+#     auth.expect(:apply, nil, [{}])
+#     auth.expect(:access_token, 'valid_token')
 
-    Google::Auth.stub(:get_application_default, auth) do
-      assert_equal('valid_token', Kubeclient::GoogleApplicationDefaultCredentials.token)
-    end
-  end
-end
+#     Google::Auth.stub(:get_application_default, auth) do
+#       assert_equal('valid_token', Kubeclient::GoogleApplicationDefaultCredentials.token)
+#     end
+#   end
+# end

--- a/test/test_google_application_default_credentials.rb
+++ b/test/test_google_application_default_credentials.rb
@@ -1,7 +1,7 @@
 require_relative 'test_helper'
 require 'googleauth'
 
-Unit tests for the ApplicationDefaultCredentials token provider
+# Unit tests for the ApplicationDefaultCredentials token provider
 class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
   def test_token
     auth = Minitest::Mock.new

--- a/test/test_google_application_default_credentials.rb
+++ b/test/test_google_application_default_credentials.rb
@@ -1,15 +1,15 @@
-# require_relative 'test_helper'
-# require 'googleauth'
+require_relative 'test_helper'
+require 'googleauth'
 
-# Unit tests for the ApplicationDefaultCredentials token provider
-# class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
-#   def test_token
-#     auth = Minitest::Mock.new
-#     auth.expect(:apply, nil, [{}])
-#     auth.expect(:access_token, 'valid_token')
+Unit tests for the ApplicationDefaultCredentials token provider
+class GoogleApplicationDefaultCredentialsTest < MiniTest::Test
+  def test_token
+    auth = Minitest::Mock.new
+    auth.expect(:apply, nil, [{}])
+    auth.expect(:access_token, 'valid_token')
 
-#     Google::Auth.stub(:get_application_default, auth) do
-#       assert_equal('valid_token', Kubeclient::GoogleApplicationDefaultCredentials.token)
-#     end
-#   end
-# end
+    Google::Auth.stub(:get_application_default, auth) do
+      assert_equal('valid_token', Kubeclient::GoogleApplicationDefaultCredentials.token)
+    end
+  end
+end

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -105,6 +105,61 @@ class TestWatch < MiniTest::Test
     end
   end
 
+  def test_watch_pod_api_bearer_token_file_success
+    stub_core_api_list
+
+    file = Tempfile.new('token')
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/', 'v1',
+      auth_options: { bearer_token_file: file.path }
+    )
+    watcher = client.watch_pods(as: :raw)
+
+    begin
+      file.write("valid_token")
+      file.rewind
+      stub_token = stub_request(:get, %r{/watch/pods})
+        .with(headers: { Authorization: 'Bearer valid_token' })
+        .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+      got = nil
+      watcher.each { |notice| got = notice }
+      assert_match(/\A{"type":"DELETED"/, got)
+      remove_request_stub(stub_token)
+
+      file.write("rotated_token")
+      file.close
+      stub_request(:get, %r{/watch/pods})
+        .with(headers: { Authorization: 'Bearer rotated_token' })
+        .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+      got = nil
+      watcher.each { |notice| got = notice }
+      assert_match(/\A{"type":"DELETED"/, got)
+    ensure
+        file.close
+        file.unlink   # deletes the temp file
+    end
+  end
+
+  def test_watch_pod_api_bearer_token_success
+    stub_core_api_list
+
+    file = Tempfile.new('token')
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/', 'v1',
+      auth_options: { bearer_token: "valid_token" }
+    )
+
+    stub_token = stub_request(:get, %r{/watch/pods})
+      .with(headers: { Authorization: 'Bearer valid_token' })
+      .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+    got = nil
+    client.watch_pods(as: :raw).each { |notice| got = notice }
+    assert_match(/\A{"type":"DELETED"/, got)
+  end
+
   # Ensure that WatchStream respects a format that's not JSON
   def test_watch_stream_text
     url = 'http://www.example.com/foobar'


### PR DESCRIPTION
https://github.com/ManageIQ/kubeclient/issues/561
It is not an optimal solution since it reads token on every request.
As an enhancement, we can watch changes in the token file and update the token when it detects any changes.