### PR TITLE
fix: move reading bearer token file to WatchStream

### DIFF
--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -754,24 +754,14 @@ module Kubeclient
     end
 
     def http_options(uri)
-      bearer_token = nil
-      if @auth_options[:bearer_token_file]
-        bearer_token_file = @auth_options[:bearer_token_file]
-        if File.file?(bearer_token_file) && File.readable?(bearer_token_file)
-          token = File.read(bearer_token_file).chomp
-          bearer_token = "Bearer #{token}"
-        end
-      elsif @auth_options[:bearer_token]
-        bearer_token = "Bearer #{@auth_options[:bearer_token]}"
-      end
-
       options = {
         basic_auth_user: @auth_options[:username],
         basic_auth_password: @auth_options[:password],
-        authorization: bearer_token,
         headers: @headers,
         http_proxy_uri: @http_proxy_uri,
-        http_max_redirects: http_max_redirects
+        http_max_redirects: http_max_redirects,
+        bearer_token_file: @auth_options[:bearer_token_file],
+        bearer_token: @auth_options[:bearer_token],
       }
 
       if uri.scheme == 'https'

--- a/lib/kubeclient/watch_stream.rb
+++ b/lib/kubeclient/watch_stream.rb
@@ -65,8 +65,19 @@ module Kubeclient
           )
         end
 
-        if @http_options[:authorization]
-          client = client.auth(@http_options[:authorization])
+        bearer_token = nil
+        if @http_options[:bearer_token_file]
+          bearer_token_file = @http_options[:bearer_token_file]
+          if File.file?(bearer_token_file) && File.readable?(bearer_token_file)
+            token = File.read(bearer_token_file).chomp
+            bearer_token = "Bearer #{token}"
+          end
+        elsif @http_options[:bearer_token]
+          bearer_token = "Bearer #{@http_options[:bearer_token]}"
+        end
+
+        if bearer_token
+          client = client.auth(bearer_token)
         end
 
         client

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -110,6 +110,7 @@ class TestWatch < MiniTest::Test
       'http://localhost:8080/api/', 'v1',
       auth_options: { bearer_token_file: file.path }
     )
+    watcher = client.watch_pods(as: :raw)
 
     begin
       file.write("valid_token")
@@ -119,7 +120,7 @@ class TestWatch < MiniTest::Test
         .to_return(body: open_test_file('watch_stream.json'), status: 200)
 
       got = nil
-      client.watch_pods(as: :raw).each { |notice| got = notice }
+      watcher.each { |notice| got = notice }
       assert_match(/\A{"type":"DELETED"/, got)
       remove_request_stub(stub_token)
 
@@ -130,12 +131,30 @@ class TestWatch < MiniTest::Test
         .to_return(body: open_test_file('watch_stream.json'), status: 200)
 
       got = nil
-      client.watch_pods(as: :raw).each { |notice| got = notice }
+      watcher.each { |notice| got = notice }
       assert_match(/\A{"type":"DELETED"/, got)
     ensure
         file.close
         file.unlink   # deletes the temp file
     end
+  end
+
+  def test_watch_pod_api_bearer_token_success
+    stub_core_api_list
+
+    file = Tempfile.new('token')
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/', 'v1',
+      auth_options: { bearer_token: "valid_token" }
+    )
+
+    stub_token = stub_request(:get, %r{/watch/pods})
+      .with(headers: { Authorization: 'Bearer valid_token' })
+      .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+    got = nil
+    client.watch_pods(as: :raw).each { |notice| got = notice }
+    assert_match(/\A{"type":"DELETED"/, got)
   end
 
   # Ensure that WatchStream respects a format that's not JSON

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -102,6 +102,42 @@ class TestWatch < MiniTest::Test
     end
   end
 
+  def test_watch_pod_api_bearer_token_file_success
+    stub_core_api_list
+
+    file = Tempfile.new('token')
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/', 'v1',
+      auth_options: { bearer_token_file: file.path }
+    )
+
+    begin
+      file.write("valid_token")
+      file.rewind
+      stub_token = stub_request(:get, %r{/watch/pods})
+        .with(headers: { Authorization: 'Bearer valid_token' })
+        .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+      got = nil
+      client.watch_pods(as: :raw).each { |notice| got = notice }
+      assert_match(/\A{"type":"DELETED"/, got)
+      remove_request_stub(stub_token)
+
+      file.write("rotated_token")
+      file.close
+      stub_request(:get, %r{/watch/pods})
+        .with(headers: { Authorization: 'Bearer rotated_token' })
+        .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+      got = nil
+      client.watch_pods(as: :raw).each { |notice| got = notice }
+      assert_match(/\A{"type":"DELETED"/, got)
+    ensure
+        file.close
+        file.unlink   # deletes the temp file
+    end
+  end
+
   # Ensure that WatchStream respects a format that's not JSON
   def test_watch_stream_text
     url = 'http://www.example.com/foobar'


### PR DESCRIPTION
WatchStream uses old bearer token, because it is not re-readed by `WatchStream`