### PR TITLE
Update HTTP gem requirement to allow version 5

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'webmock', '~> 3.0'

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 1.1'
   spec.add_dependency 'faraday_middleware', '~> 1.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
-  spec.add_dependency 'http', '>= 3.0', '< 5.0'
+  spec.add_dependency 'http', '>= 3.0', '< 6.0'
 end


### PR DESCRIPTION
I wanted to use kubeclient in a project and noticed it required me to downgrade the version of the http gem to version 4. Version 5.0.0 of the http gem was released more than a year ago. Their [changelog](https://github.com/httprb/http/blob/main/CHANGES.md) notes some breaking changes, but none of them seem to impact the usage in kubeclient.

This pull request also updates the rake development dependency to version 13. It looks like version 13 was [released almost three years ago](https://github.com/ruby/rake/releases/tag/v13.0.0). Updating it was the easiest way to use version 5 of the http gem in kubeclient since it is dependent on the llhttp-ffi gem, which apparently is dependent on rake 13. I very much doubt that llhttp-ffi actually needs rake at runtime, but it is what it is. And actually updating rake here does make sense after three years.