### PR TITLE
Fix Ruby 2.6 & 2.7 failing GoogleApplicationDefaultCredentialsTest

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest', '~> 5.15.0'
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'vcr'


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/kubeclient/issues/569

I think the issue is produced in minitest v5.16.0
http://docs.seattlerb.org/minitest/History_rdoc.html#label-5.16.0+-2F+2022-06-14
> Had to patch up mock and stub to deal with <=2.7 kwargs oddities