### PR TITLE
Update CHANGELOG (and version) on master to reflect 4.10.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,21 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 ### Changed
 - `Kubeclient::Client.new` now always requires an api version, use for example: `Kubeclient::Client.new(uri, 'v1')`
 
-## 4.9.3 — 2021-03-23
+## 4.10.0 — 2022-08-29
+
+### Added
+
+- When using `:bearer_token_file`, re-read the file on every request. (#566 closed #561)
+
+  Kubernetes version 1.21 graduated [BoundServiceAccountTokenVolume feature][] to beta
+  and enabled it by default, so standard in-cluster auth now uses short-lived tokens.
+
+  This changes allows a long-lived `Client` object to keep working when the token file gets
+  rotated.  It's not optimized at all, if you feel the performance overhead, please report!
+
+  [BoundServiceAccountTokenVolume feature]: https://github.com/kubernetes/enhancements/issues/542
+
+## 4.9.3 — 2022-03-23
 
 ### Fixed
 

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.9.3'
+  VERSION = '4.10.0'
 end


### PR DESCRIPTION
Cherry-pick #574 from cben/release-4.10.0 (commit 1bef6a84be07ab3f953a6e3e51992d8857adceee)