### PR TITLE
use openid_connect gem's jwks caching feature

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.3.0' # locked to minor so new cops don't slip in
   spec.add_development_dependency 'googleauth', '~> 0.5'
   spec.add_development_dependency('mocha', '~> 1.5')
-  spec.add_development_dependency 'openid_connect', '~> 1.1'
+  spec.add_development_dependency 'openid_connect', '~> 1.4'
   spec.add_development_dependency 'net-smtp'
 
   spec.add_dependency 'faraday', '~> 1.1'

--- a/lib/kubeclient/oidc_auth_provider.rb
+++ b/lib/kubeclient/oidc_auth_provider.rb
@@ -40,7 +40,7 @@ module Kubeclient
       def expired?(id_token, discovery)
         decoded_token = OpenIDConnect::ResponseObject::IdToken.decode(
           id_token,
-          discovery.jwks
+          discovery
         )
         # If token expired or expiring within 60 seconds
         Time.now.to_i + 60 > decoded_token.exp.to_i


### PR DESCRIPTION
same with https://github.com/omniauth/omniauth_openid_connect/pull/124

when passing `OpenIDConnect::Discovery::Provider::Config::Response` instance to `OpenIDConnect::ResponseObject::IdToken.decode`, it fetches JWK Set using `JSON::JWK::Set::Fetcher`.

`JSON::JWK::Set::Fetcher` tries to cache JWKS by given `kid` when `JSON::JWK::Set::Fetcher.cache` is setup like below.

```ruby
JSON::JWK::Set::Fetcher.cache = Rails.cache
```