### PR TITLE
Update CHANGELOG (and version) on master to reflect 4.10.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 ### Changed
 - `Kubeclient::Client.new` now always requires an api version, use for example: `Kubeclient::Client.new(uri, 'v1')`
 
+## 4.10.1 — 2022-10-01
+
+### Removed
+
+- Dropped debug logging about bearer token options that was added in 4.10.0. (#577)
+
 ## 4.10.0 — 2022-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ client = Kubeclient::Client.new(
 ### Authentication
 
 If you are using basic authentication or bearer tokens as described
-[here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/authentication.md) then you can specify one
-of the following:
+[here](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/authentication.md)
+then you can specify one of the following:
 
 ```ruby
 auth_options = {
@@ -112,7 +112,7 @@ client = Kubeclient::Client.new(
 )
 ```
 
-or
+or (fixed token, if it expires it's up to you to create a new `Client` object):
 
 ```ruby
 auth_options = {
@@ -123,7 +123,7 @@ client = Kubeclient::Client.new(
 )
 ```
 
-or
+or (will automatically re-read the token if file is updated):
 
 ```ruby
 auth_options = {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,10 +4,6 @@
 Kubeclient release versioning follows [SemVer](https://semver.org/).
 At some point in time it is decided to release version x.y.z.
 
-```bash
-RELEASE_BRANCH="master"
-```
-
 ## 0. (once) Install gem-release, needed for several commands here:
 
 ```bash
@@ -16,13 +12,17 @@ gem install gem-release
 
 ## 1. PR(s) for changelog & bump
 
+```bash
+RELEASE_BRANCH="master"
+RELEASE_VERSION=x.y.z
+
+git checkout -b "release-$RELEASE_VERSION" $RELEASE_BRANCH
+```
+
 Edit `CHANGELOG.md` as necessary.  Even if all included changes remembered to update it, you should replace "Unreleased" section header with appropriate "x.y.z — 20yy-mm-dd" header.
 
 Bump `lib/kubeclient/version.rb` manually, or by using:
 ```bash
-RELEASE_VERSION=x.y.z
-
-git checkout -b "release-$RELEASE_VERSION" $RELEASE_BRANCH
 # Won't work with uncommitted changes, you have to commit the changelog first.
 gem bump --version $RELEASE_VERSION
 git show # View version bump change.
@@ -46,7 +46,7 @@ Make sure we're locally after the bump PR *merge commit*:
 ```bash
 git checkout $RELEASE_BRANCH
 git status # Make sure there are no local changes
-git pull --ff-only https://github.com/abonas/kubeclient $RELEASE_BRANCH
+git pull --ff-only https://github.com/ManageIQ/kubeclient $RELEASE_BRANCH
 git log -n1
 ```
 

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.10.0'
+  VERSION = '4.10.1'.freeze
 end


### PR DESCRIPTION
Changelog & bump for 4.10.1 release

(cherry picked from commit b722dee74aea7fdc81646b35a0fc815ff1f5610b)

Reference: https://github.com/ManageIQ/kubeclient/issues/580