### PR TITLE
Drop EOL ruby 2.5, 2.6 from CI on master branch.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os_and_command.os }}
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head' ]
+        ruby: [ '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head' ]
         os_and_command:
         - os: 'macos-latest'
           command: 'env TESTOPTS="--verbose" bundle exec rake test'
@@ -24,9 +24,10 @@ jobs:
           command: 'timeout --signal=TERM 3m env TESTOPTS="--verbose" test/config/update_certs_k0s.rb'
         include:
         # run rubocop against lowest supported ruby
-        - os: ubuntu-latest
-          ruby: '2.5'
-          command: 'bundle exec rake rubocop'
+        - ruby: '2.7'
+          os_and_command:
+            os: ubuntu-latest
+            command: 'bundle exec rake rubocop'
     name: ${{ matrix.os_and_command.os }} ${{ matrix.ruby }} rake ${{ matrix.os_and_command.command }}
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5 # Oldest version kubeclient supports
+  TargetRubyVersion: 2.7 # Oldest version kubeclient supports
   NewCops: enable
 Metrics/MethodLength:
   Enabled: false

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = git_files.grep_v(%r{^(test|spec|features)/})
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = []
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -225,7 +225,7 @@ module Kubeclient
           # So don't expect full last word to match.
           /^(?<prefix>.*[A-Z])(?<singular_suffix>[^A-Z]*)$/ =~ kind # "NetworkP", "olicy"
           if name.start_with?(prefix.downcase)
-            plural_suffix = name[prefix.length..-1] # "olicies"
+            plural_suffix = name[prefix.length..] # "olicies"
             prefix_underscores = underscore_entity(prefix) # "network_p"
             method_names = [
               prefix_underscores + singular_suffix, # "network_policy"
@@ -482,7 +482,8 @@ module Kubeclient
     #   :orphan_dependents (bool) - should the dependent objects be orphaned
     #   :propagation_policy (string) - one of Foreground|Background|Orphan
     #   :resource_version (string) - sets a limit on the resource versions that can be served
-    #   :resource_version_match (string) - determines how the resource_version constraint will be applied
+    #   :resource_version_match (string) - determines how the resource_version constraint
+    #     will be applied
     #   :timeout_seconds (integer) - limits the duraiton of the call
     #   :continue (string) - a token used to retrieve the next chunk of entities
     #   :as (:raw|:ros) - defaults to :ros
@@ -761,7 +762,7 @@ module Kubeclient
         http_proxy_uri: @http_proxy_uri,
         http_max_redirects: http_max_redirects,
         bearer_token_file: @auth_options[:bearer_token_file],
-        bearer_token: @auth_options[:bearer_token],
+        bearer_token: @auth_options[:bearer_token]
       }
 
       if uri.scheme == 'https'

--- a/lib/kubeclient/version.rb
+++ b/lib/kubeclient/version.rb
@@ -2,5 +2,5 @@
 
 # Kubernetes REST-API Client
 module Kubeclient
-  VERSION = '4.10.1'.freeze
+  VERSION = '4.10.1'
 end

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -113,18 +113,18 @@ class TestWatch < MiniTest::Test
     watcher = client.watch_pods(as: :raw)
 
     begin
-      file.write("valid_token")
+      file.write('valid_token')
       file.rewind
       stub_token = stub_request(:get, %r{/watch/pods})
-        .with(headers: { Authorization: 'Bearer valid_token' })
-        .to_return(body: open_test_file('watch_stream.json'), status: 200)
+                   .with(headers: { Authorization: 'Bearer valid_token' })
+                   .to_return(body: open_test_file('watch_stream.json'), status: 200)
 
       got = nil
       watcher.each { |notice| got = notice }
       assert_match(/\A{"type":"DELETED"/, got)
       remove_request_stub(stub_token)
 
-      file.write("rotated_token")
+      file.write('rotated_token')
       file.close
       stub_request(:get, %r{/watch/pods})
         .with(headers: { Authorization: 'Bearer rotated_token' })
@@ -134,8 +134,8 @@ class TestWatch < MiniTest::Test
       watcher.each { |notice| got = notice }
       assert_match(/\A{"type":"DELETED"/, got)
     ensure
-        file.close
-        file.unlink   # deletes the temp file
+      file.close
+      file.unlink # deletes the temp file
     end
   end
 
@@ -145,16 +145,19 @@ class TestWatch < MiniTest::Test
     file = Tempfile.new('token')
     client = Kubeclient::Client.new(
       'http://localhost:8080/api/', 'v1',
-      auth_options: { bearer_token: "valid_token" }
+      auth_options: { bearer_token: 'valid_token' }
     )
 
-    stub_token = stub_request(:get, %r{/watch/pods})
+    stub_request(:get, %r{/watch/pods})
       .with(headers: { Authorization: 'Bearer valid_token' })
       .to_return(body: open_test_file('watch_stream.json'), status: 200)
 
     got = nil
     client.watch_pods(as: :raw).each { |notice| got = notice }
     assert_match(/\A{"type":"DELETED"/, got)
+  ensure
+    file.close
+    file.unlink # deletes the temp file
   end
 
   # Ensure that WatchStream respects a format that's not JSON


### PR DESCRIPTION
Also:
- Fix rubocop: Apparently for a while I had a broken github actions config so Rubocop
wasn't actually running in CI... :man_facepalming: 
  Plus adjust to some new linting from bumping rubocop's TargetRubyVersion.

- Fix test_watch_pod_api_bearer_token_success leaking a temp file.