### PR TITLE
informer test flakyness: try reporting problems earlier

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,8 @@ require 'mocha/minitest'
 require 'json'
 require_relative '../lib/kubeclient'
 
+Thread.abort_on_exception = true
+
 MiniTest::Test.class_eval do
   # Assumes test files will be in a subdirectory with the same name as the
   # file suffix.  e.g. a file named foo.json would be a "json" subdirectory.


### PR DESCRIPTION
https://github.com/ManageIQ/kubeclient/issues/584 describes a few cases where the test got stuck and one looked like it watched twice ... one way that could happen if we retry the loop and log errors ... so let's make that explode instead so we see what the real underlying error is
@cben 