### PR TITLE
informer test: reduce flakyness by waiting for correct state

### DIFF
--- a/lib/kubeclient/informer.rb
+++ b/lib/kubeclient/informer.rb
@@ -65,17 +65,17 @@ module Kubeclient
     end
 
     def watch_to_update_cache
-      watcher = @client.watch_entities(@resource_name, watch: true, resource_version: @started)
+      @watcher = @client.watch_entities(@resource_name, watch: true, resource_version: @started)
       stop_reason = 'disconnect'
 
       # stop watcher without using timeout
       Thread.new do
         sleep(@reconcile_timeout)
         stop_reason = 'reconcile'
-        watcher.finish
+        @watcher.finish
       end
 
-      watcher.each do |notice|
+      @watcher.each do |notice|
         case notice[:type]
         when 'ADDED', 'MODIFIED' then @cache[cache_key(notice[:object])] = notice[:object]
         when 'DELETED' then @cache.delete(cache_key(notice[:object]))

--- a/test/test_informer.rb
+++ b/test/test_informer.rb
@@ -141,7 +141,8 @@ class RetryTest < MiniTest::Test
 
   def with_worker
     informer.start_worker
-    sleep(0.03) # wait for worker to watch
+    sleep(0.01) until informer.instance_variable_get(:@watcher) # wait for worker to watch
+    sleep(0.01) # give some time for threads to store
     yield
   ensure
     informer.stop_worker


### PR DESCRIPTION
hopefully improving on https://github.com/ManageIQ/kubeclient/pull/586#issuecomment-1328202844
before we waited a set amount of time and now we wait until the watcher is ready
... which will stop and fail in that spot if it never got ready