### PR TITLE
Update actions/checkout

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,7 +30,7 @@ jobs:
             command: 'bundle exec rake rubocop'
     name: ${{ matrix.os_and_command.os }} ${{ matrix.ruby }} rake ${{ matrix.os_and_command.command }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # actions/setup-ruby did not support truffle or bundler caching
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
### Why
Related to https://github.com/ManageIQ/kubeclient/issues/582 

We're getting deprecation warnings in CI due to node12.

### What
Moving to [actions/checkout@v3](https://github.com/actions/checkout#whats-new) switches us from node12 to the node16 runtime default.
