### PR TITLE
Update googleauth dependency

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-rg'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.3.0' # locked to minor so new cops don't slip in
-  spec.add_development_dependency 'googleauth', '~> 0.5'
+  spec.add_development_dependency 'googleauth', '~> 1.3'
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'net-smtp'


### PR DESCRIPTION
### Why

I did some research on this issue https://github.com/ManageIQ/kubeclient/issues/564

It looks like to get openid connect up to date we'll need to get to Faraday v2, but our current version of googleauth constrains below that.

So it seems that getting the googleauth dependency into v1 is a necessary first step to addressing the issue.

### What
- update the googleauth dependency (here's the [the changelog](https://github.com/googleapis/google-auth-library-ruby/blob/main/CHANGELOG.md))
- ran tests locally, all passed 
 
If a more incremental approach to dependency updates are desired, I'm happy to approach this differently. 

Let me know what you think 👍 