### PR TITLE
use forking-test-runner to ensure no test pollution between different…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,20 @@
 # frozen_string_literal: true
 
 require 'bundler/gem_tasks'
-require 'rake/testtask'
 require 'rubocop/rake_task'
 require 'yaml'
 
 task default: %i[test rubocop] # same as .github/workflows/actions.yml
 
-Rake::TestTask.new
+begin
+  fork { nil }
+rescue NotImplementedError
+  # jruby and windows can't fork so use vanilla rake instead
+  require 'rake/testtask'
+else
+  desc 'Run each test in isolation'
+  task :test do
+    sh 'forking-test-runner test/test_* --helper test/helper.rb --verbose'
+  end
+end
 RuboCop::RakeTask.new

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('mocha', '~> 1.5')
   spec.add_development_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'net-smtp'
+  spec.add_development_dependency 'forking_test_runner'
 
   spec.add_dependency 'faraday', '~> 1.1'
   spec.add_dependency 'faraday_middleware', '~> 1.0'


### PR DESCRIPTION
… test files

maybe this cuts down on the random errors
... and even if not it should reduce wild goose chases if one test messes with global state