### PR TITLE
support impersonation via auth_options and in kubectl config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ## Unreleased — to become 5.y.z
 
+### Added
+- Added impersonation support. Limited to at most 1 group in `as_groups` and 1 value for each `as_user_extra` field. (#600)
+
 ### Changed
 - `Kubeclient::Client.new` now always requires an api version, use for example: `Kubeclient::Client.new(uri, 'v1')`
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,24 @@ You can read it as follows:
 puts config.context.namespace
 ```
 
+### Impersonation
+
+Impersonation is supported when loading a kubectl config and via the Ruby API, for example:
+
+```ruby
+client = Kubeclient::Client.new(
+  context.api_endpoint, 'v1',
+  auth_options: {
+    as: "admin",
+    as_groups: ["system:masters"],
+    as_uid: "123", # optional
+    as_user_extra: {
+      "reason" => ["admin access"]
+    }
+  }
+)
+```
+
 ### Supported kubernetes versions
 
 We try to support the last 3 minor versions, matching the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew).

--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ client = Kubeclient::Client.new(
 )
 ```
 
+Note that only one group and one value per each extra field are currently supported. Using list of multiple values
+will result in `ArgumentError`.
+
 ### Supported kubernetes versions
 
 We try to support the last 3 minor versions, matching the [official support policy for Kubernetes](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md#supported-releases-and-component-skew).

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -368,7 +368,8 @@ module Kubeclient
           client_key: @ssl_options[:client_key],
           verify: @ssl_options[:verify_ssl] != OpenSSL::SSL::VERIFY_NONE,
           verify_mode: @ssl_options[:verify_ssl]
-        }
+        },
+        headers: @headers
       }
 
       Faraday.new(url, options) do |connection|

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -183,6 +183,16 @@ module Kubeclient
           options[attr.to_sym] = user[attr] if user.key?(attr)
         end
       end
+
+      # TODO: allow setting Impersonate-Uid from here or comment on why it is not possible
+      [
+        ['as', :as],
+        ['as-groups', :as_groups],
+        ['as-user-extra', :as_user_extra]
+      ].each do |k, v|
+        options[v] = user[k] if user.key?(k)
+      end
+
       options
     end
 

--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -60,6 +60,7 @@ module Kubeclient
       client_cert_data = fetch_user_cert_data(user)
       client_key_data  = fetch_user_key_data(user)
       auth_options     = fetch_user_auth_options(user)
+      auth_options.merge!(fetch_user_impersonate_options(user))
 
       ssl_options = {}
 
@@ -183,16 +184,14 @@ module Kubeclient
           options[attr.to_sym] = user[attr] if user.key?(attr)
         end
       end
+      options
+    end
 
-      # TODO: allow setting Impersonate-Uid from here or comment on why it is not possible
-      [
-        ['as', :as],
-        ['as-groups', :as_groups],
-        ['as-user-extra', :as_user_extra]
-      ].each do |k, v|
-        options[v] = user[k] if user.key?(k)
-      end
-
+    def fetch_user_impersonate_options(user)
+      options = {}
+      options[:as] = user['as'] if user.key?('as')
+      options[:as_groups] = user['as-groups'] if user.key?('as-groups')
+      options[:as_user_extra] = user['as-user-extra'] if user.key?('as-user-extra')
       options
     end
 

--- a/test/config/impersonate-empty-groups.kubeconfig
+++ b/test/config/impersonate-empty-groups.kubeconfig
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+    insecure-skip-tls-verify: true
+  name: localhost:8443
+contexts:
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: impersonate
+  name: localhost/impersonate
+current-context: localhost/impersonate
+kind: Config
+preferences: {}
+users:
+- name: impersonate
+  user:
+    as: foo
+    as-groups: []
+    as-user-extra:
+      reason: []

--- a/test/config/impersonate.kubeconfig
+++ b/test/config/impersonate.kubeconfig
@@ -1,0 +1,22 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8443
+    insecure-skip-tls-verify: true
+  name: localhost:8443
+contexts:
+- context:
+    cluster: localhost:8443
+    namespace: default
+    user: impersonate
+  name: localhost/impersonate
+current-context: localhost/impersonate
+kind: Config
+preferences: {}
+users:
+- name: impersonate
+  user:
+    as: foo
+    as-groups: [bar, baz]
+    as-user-extra:
+      reason: [foo]

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -233,6 +233,19 @@ class KubeclientConfigTest < MiniTest::Test
     config.context(config.contexts.first)
   end
 
+  def test_impersonate
+    parsed = YAML.safe_load(File.read(config_file('impersonate.kubeconfig')))
+    config = Kubeclient::Config.new(parsed, nil)
+    assert_equal(
+      {
+        as: 'foo',
+        as_groups: ['bar', 'baz'],
+        as_user_extra: { 'reason' => ['foo'] }
+      },
+      config.context(config.contexts.first).auth_options
+    )
+  end
+
   private
 
   def check_context(context, ssl: true, custom_ca: true, client_cert: true)

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -246,6 +246,19 @@ class KubeclientConfigTest < MiniTest::Test
     )
   end
 
+  def test_impersonate_empty_groups
+    parsed = YAML.safe_load(File.read(config_file('impersonate-empty-groups.kubeconfig')))
+    config = Kubeclient::Config.new(parsed, nil)
+    assert_equal(
+      {
+        as: 'foo',
+        as_groups: [],
+        as_user_extra: { 'reason' => [] }
+      },
+      config.context(config.contexts.first).auth_options
+    )
+  end
+
   private
 
   def check_context(context, ssl: true, custom_ca: true, client_cert: true)

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -841,6 +841,37 @@ class KubeclientTest < MiniTest::Test
     assert_equal(1, pods.size)
   end
 
+  def test_impersonate
+    stub_request(:get, 'http://localhost:8080/api/v1/pods')
+      .with(
+        headers: {
+          Authorization: 'Bearer valid_token',
+          'Impersonate-Extra-Reason': 'baz',
+          'Impersonate-Group': 'bar',
+          'Impersonate-User': 'foo',
+          'Impersonate-Uid': '123'
+        }
+      )
+      .to_return(body: { items: [] }.to_json)
+    stub_request(:get, %r{/api/v1$})
+      .with(headers: { Authorization: 'Bearer valid_token' })
+      .to_return(body: open_test_file('core_api_resource_list.json'))
+
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      'v1',
+      auth_options: {
+        bearer_token: 'valid_token',
+        as: 'foo',
+        as_groups: ['bar'],
+        as_user_extra: { 'reason' => ['baz'] },
+        as_uid: '123'
+      }
+    )
+
+    client.get_pods
+  end
+
   def test_proxy_url
     stub_core_api_list
 

--- a/test/test_watch.rb
+++ b/test/test_watch.rb
@@ -311,6 +311,34 @@ class TestWatch < MiniTest::Test
     assert_requested(watch_stub)
   end
 
+  def test_watch_impersonation_headers_empty_values
+    stub_core_api_list
+    watch_headers = nil
+    watch_stub = stub_request(:get, %r{/watch/pods})
+                 .with { |request| watch_headers = request.headers }
+                 .to_return(body: open_test_file('watch_stream.json'), status: 200)
+
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/',
+      'v1',
+      auth_options: {
+        as: 'admin',
+        as_groups: [],
+        as_user_extra: {
+          'reason' => [],
+          'scope' => []
+        }
+      }
+    )
+    yielded = []
+    client.watch_pods { |notice| yielded << notice.type }
+    assert_requested(watch_stub)
+    assert_includes(watch_headers, 'Impersonate-User')
+    refute_includes(watch_headers, 'Impersonate-Group')
+    refute_includes(watch_headers, 'Impersonate-Extra-Reason')
+    refute_includes(watch_headers, 'Impersonate-Extra-Scope')
+  end
+
   private
 
   def start_http_server(host: '127.0.0.1', port: Random.rand(1000..10_999))


### PR DESCRIPTION
This PR is rebase and update of https://github.com/ManageIQ/kubeclient/pull/524 to current master version

We tested it and it works as expected

Ruby http clients (including adapters for Faraday) are not able to handle multiple headers of same name, which is how the kube API expects to receive the list of multiple groups or extra fields. To avoid any confusion, added explicit error when trying to configure client with multivalue groups. **This may brake some applications, if user is not aware of the impersonation setting and were ignoring it until now**