### PR TITLE
Enable refreshing of auth_provider bearer_token

### DIFF
--- a/lib/kubeclient/config.rb
+++ b/lib/kubeclient/config.rb
@@ -199,9 +199,9 @@ module Kubeclient
       case auth_provider['name']
       when 'gcp'
         config = expand_command_option(auth_provider['config'], 'cmd-path')
-        Kubeclient::GCPAuthProvider.token(config)
+        -> { Kubeclient::GCPAuthProvider.token(config) }
       when 'oidc'
-        Kubeclient::OIDCAuthProvider.token(auth_provider['config'])
+        -> { Kubeclient::OIDCAuthProvider.token(auth_provider['config']) }
       end
     end
 

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -841,6 +841,38 @@ class KubeclientTest < MiniTest::Test
     assert_equal(1, pods.size)
   end
 
+  def test_api_bearer_token_file_refreshes
+    stub_core_api_list
+
+    file = File.join(File.dirname(__FILE__), 'valid_token_file')
+    client = Kubeclient::Client.new(
+      'http://localhost:8080/api/', 'v1',
+      auth_options: { bearer_token_file: file }
+    )
+
+    first_request = stub_request(:get, 'http://localhost:8080/api/v1/pods')
+                    .with(headers: { Authorization: 'Bearer valid_token' })
+                    .to_return(body: '{}', status: 200)
+
+    client.get_pods
+
+    assert_requested(first_request)
+
+    WebMock.reset!
+
+    File.open(file, 'w') { |f| f.puts('another_valid_token') }
+
+    second_request = stub_request(:get, 'http://localhost:8080/api/v1/pods')
+                     .with(headers: { Authorization: 'Bearer another_valid_token' })
+                     .to_return(body: '{}', status: 200)
+
+    client.get_pods
+
+    assert_requested(second_request)
+  ensure
+    File.open(file, 'w') { |f| f.puts('valid_token') }
+  end
+
   def test_impersonate
     pods_stub = stub_request(:get, 'http://localhost:8080/api/v1/pods')
                 .with(


### PR DESCRIPTION
Ref: #393

Previously, once a Kubeclient::Context was created, auth_provider bearer_tokens would be set and never refreshed.

This commit enables automatic refreshing of auth_provider bearer_tokens by returning callables instead of static tokens. When used with the faraday client, the callable is automatically called for each request, and for the non-faraday client the callable is called before setting the header manually.

Tests have been updated to cover this functionality for both client types, and an additional test was added for refreshing bearer_token_file because it did not appear to be covered before.