### PR TITLE
Add test coverage for Ruby 3.2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os_and_command.os }}
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', 'ruby-head', 'truffleruby-head' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'truffleruby-head' ]
         os_and_command:
         - os: 'macos-latest'
           command: 'env TESTOPTS="--verbose" bundle exec rake test'


### PR DESCRIPTION
GitLab is planning to upgrade ruby version to 3.1 first, and later to 3.2. For the preparation, we're checking if dependencies are compatible with these versions. (See https://gitlab.com/gitlab-org/gitlab/-/issues/404750 for more information)

This PR adds the test coverage for Ruby 3.2.