### PR TITLE
feat: support both faraday 1.x and 2.x

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby: [ '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'truffleruby-head' ]
+        gemfile: ["test/gemfiles/Gemfile.faraday-1", "test/gemfiles/Gemfile.faraday-2"]
         os_and_command:
         - os: 'macos-latest'
           command: 'env TESTOPTS="--verbose" bundle exec rake test'
@@ -25,10 +26,13 @@ jobs:
         include:
         # run rubocop against lowest supported ruby
         - ruby: '2.7'
+          gemfile: 'Gemfile'
           os_and_command:
             os: ubuntu-latest
             command: 'bundle exec rake rubocop'
-    name: ${{ matrix.os_and_command.os }} ${{ matrix.ruby }} rake ${{ matrix.os_and_command.command }}
+    name: ${{ matrix.os_and_command.os }} ${{ matrix.ruby }} ${{ matrix.gemfile }} rake ${{ matrix.os_and_command.command }}
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
     - uses: actions/checkout@v3
     # actions/setup-ruby did not support truffle or bundler caching

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mkmf.log
 *.idea*
 /Gemfile.dev.rb
+/test/gemfiles/*.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Kubeclient release versioning follows [SemVer](https://semver.org/).
 
 ### Changed
 - `Kubeclient::Client.new` now always requires an api version, use for example: `Kubeclient::Client.new(uri, 'v1')`
+- `faraday` is used as HTTP client instead of `rest_client`, supports both `1.x` and `2.x` `faraday` versions
 
 ### TODO: lots of changes on master branch missing here!
 

--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'net-smtp'
   spec.add_development_dependency 'forking_test_runner'
 
-  spec.add_dependency 'faraday', '~> 1.1'
-  spec.add_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_dependency 'faraday', '>= 1.1', '< 3.0'
+  spec.add_dependency 'faraday-follow_redirects', '>= 0.3.0'
   spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
   spec.add_dependency 'http', '>= 3.0', '< 6.0'
 end

--- a/test/gemfiles/Gemfile.faraday-1
+++ b/test/gemfiles/Gemfile.faraday-1
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in kubeclient.gemspec
+gemspec :path => '../../'
+
+gem 'faraday', '~> 1.1'

--- a/test/gemfiles/Gemfile.faraday-2
+++ b/test/gemfiles/Gemfile.faraday-2
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in kubeclient.gemspec
+gemspec :path => '../../'
+
+gem 'faraday', '~> 2.0'

--- a/test/test_kubeclient.rb
+++ b/test/test_kubeclient.rb
@@ -4,6 +4,9 @@ require_relative 'helper'
 
 # Kubernetes client entity tests
 class KubeclientTest < MiniTest::Test
+  class TestFaradayMiddleware # rubocop:disable Lint/EmptyClass:
+  end
+
   def test_json
     our_object = Kubeclient::Resource.new
     our_object.foo = 'bar'
@@ -341,12 +344,12 @@ class KubeclientTest < MiniTest::Test
 
   def test_custom_faraday_config_options
     client = Kubeclient::Client.new('http://localhost:8080/api/', 'v1')
-    expected_middlewares = [FaradayMiddleware::FollowRedirects, Faraday::Response::RaiseError]
+    expected_middlewares = [Faraday::FollowRedirects::Middleware, Faraday::Response::RaiseError]
     expected_middlewares.each do |klass|
       assert(client.faraday_client.builder.handlers.include?(klass))
     end
-    client.configure_faraday { |connection| connection.use(Faraday::Request::Retry) }
-    expected_middlewares << Faraday::Request::Retry
+    client.configure_faraday { |connection| connection.use(TestFaradayMiddleware) }
+    expected_middlewares << TestFaradayMiddleware
     expected_middlewares.each do |klass|
       assert(client.faraday_client.builder.handlers.include?(klass))
     end


### PR DESCRIPTION
* Remove specific version dependency for faraday from gemfile. This allows users to use any version in their application.
* Update code to support both 1.x and 2.x versions - there is one small difference in use of auth middleware ([see docs](https://lostisland.github.io/faraday/middleware/authentication))
* Use `faraday-follow_redirects` gem that is compatible with 1.x and 2.x as well - instead of deprecated `faraday_middleware` gem
* Added CI groups for each faraday 1 and faraday 2 Gemfiles
* Added mention to CHANGELOG