### PR TITLE
feat: add timeout_seconds option to Kubeclient::Client#watch_entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ client = Kubeclient::Client.new(
 
 ### Timeouts
 
-Watching configures the socket to never time out (however, sooner or later all watches terminate).
+Watching configures the socket to never time out by default (however, sooner or later all watches terminate).
 
 One-off actions like `.get_*`, `.delete_*` have a configurable timeout:
 ```ruby
@@ -622,6 +622,13 @@ You can use `allow_watch_bookmarks: true` to get `BOOKMARK` events returned regu
 ```ruby
 client.watch_pods allow_watch_bookmarks: true do |notice|
   # process notice data
+end
+```
+
+To limit the maximum duration of a watch on the server, pass the `timeout_seconds:` param.
+```ruby
+client.watch_pods(timeout_seconds: 120, namespace: ns) do |notice|
+  ...
 end
 ```
 

--- a/lib/kubeclient.rb
+++ b/lib/kubeclient.rb
@@ -77,10 +77,11 @@ module Kubeclient
     }.freeze
 
     WATCH_ARGUMENTS = {
-      'labelSelector'   => :label_selector,
-      'fieldSelector'   => :field_selector,
-      'resourceVersion' => :resource_version,
-      'allowWatchBookmarks' => :allow_watch_bookmarks
+      'labelSelector'       => :label_selector,
+      'fieldSelector'       => :field_selector,
+      'resourceVersion'     => :resource_version,
+      'allowWatchBookmarks' => :allow_watch_bookmarks,
+      'timeoutSeconds'      => :timeout_seconds
     }.freeze
 
     attr_reader :api_endpoint
@@ -408,6 +409,7 @@ module Kubeclient
     #   :label_selector (string) - a selector to restrict the list of returned objects by labels.
     #   :field_selector (string) - a selector to restrict the list of returned objects by fields.
     #   :resource_version (string) - shows changes that occur after passed version of a resource.
+    #   :timeout_seconds (integer) - limits the duration of the call
     #   :as (:raw|:ros) - defaults to :ros
     #     :raw - return the raw response body as a string
     #     :ros - return a collection of RecursiveOpenStruct objects
@@ -493,7 +495,7 @@ module Kubeclient
     #   :resource_version (string) - sets a limit on the resource versions that can be served
     #   :resource_version_match (string) - determines how the resource_version constraint
     #     will be applied
-    #   :timeout_seconds (integer) - limits the duraiton of the call
+    #   :timeout_seconds (integer) - limits the duration of the call
     #   :continue (string) - a token used to retrieve the next chunk of entities
     #   :as (:raw|:ros) - defaults to :ros
     #     :raw - return the raw response body as a string


### PR DESCRIPTION
This small PR adds a "timeout_seconds" option to the "Kubeclient::Client#watch_entities" method (not set by default).
The objective is to limit the duration of a watch to prevent zombification if the watch lasts for too long (see #512).

We see the zombification often on Azure kubernetes cluster, where our watch stays up but does not receive notifications anymore. By setting a timeout_seconds of X seconds we are sure that we are not zombified for more than X seconds.

Happy to take feedback to improve this PR.