### PR TITLE
Fix bundler version failure with ruby 2.7

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: false # disable running 'bundle install' and caching installed gems see https://github.com/httprb/http/issues/572
-    - run: gem install rake bundler
     - run: bundle install
     - run: ${{ matrix.os_and_command.command }}
     timeout-minutes: 10


### PR DESCRIPTION
The kubeclient actions.yml was manually installing rake and bundler overriding what `ruby/setup-ruby` was installing.  This would attempt to install the latest version of bundler which is not supported on ruby 2.7 so the gem install was failing [[ref]](https://github.com/ManageIQ/kubeclient/actions/runs/8520658964/job/23345583298#step:4:1)

```
Run gem install rake bundler
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
Successfully installed rake-13.2.0
1 gem installed
Error: Process completed with exit code 1.
```

`ruby/setup-ruby` will install the correct bundler for the version of ruby requested.