### PR TITLE
Backport changes to the AWS EKS Credentials into the v4.y branch for release

### DIFF
--- a/lib/kubeclient/aws_eks_credentials.rb
+++ b/lib/kubeclient/aws_eks_credentials.rb
@@ -7,30 +7,40 @@ module Kubeclient
     end
 
     class << self
-      def token(credentials, eks_cluster)
+      def token(credentials, eks_cluster, region: 'us-east-1')
         begin
           require 'aws-sigv4'
           require 'base64'
           require 'cgi'
         rescue LoadError => e
           raise AmazonEksDependencyError,
-                'Error requiring aws gems. Kubeclient itself does not include the following ' \
+            'Error requiring aws gems. Kubeclient itself does not include the following ' \
                 'gems: [aws-sigv4]. To support auth-provider eks, you must ' \
                 "include it in your calling application. Failed with: #{e.message}"
         end
         # https://github.com/aws/aws-sdk-ruby/pull/1848
         # Get a signer
         # Note - sts only has ONE endpoint (not regional) so 'us-east-1' hardcoding should be OK
-        signer = Aws::Sigv4::Signer.new(
-          service: 'sts',
-          region: 'us-east-1',
-          credentials: credentials
-        )
+        signer = if credentials.respond_to?(:credentials)
+                   Aws::Sigv4::Signer.new(
+                     service: 'sts',
+                     region: region,
+                     credentials_provider: credentials
+                   )
+                 else
+                   Aws::Sigv4::Signer.new(
+                     service: 'sts',
+                     region: region,
+                     credentials: credentials
+                   )
+                 end
+
+        credentials = credentials.credentials if credentials.respond_to?(:credentials)
 
         # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Sigv4/Signer.html#presign_url-instance_method
         presigned_url_string = signer.presign_url(
           http_method: 'GET',
-          url: 'https://sts.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15',
+          url: "https://sts.#{region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15",
           body: '',
           credentials: credentials,
           expires_in: 60,
@@ -38,8 +48,7 @@ module Kubeclient
             'X-K8s-Aws-Id' => eks_cluster
           }
         )
-        kube_token = 'k8s-aws-v1.' + Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=*$/, '') # rubocop:disable Metrics/LineLength
-        kube_token
+        "k8s-aws-v1.#{Base64.urlsafe_encode64(presigned_url_string.to_s).sub(/=*$/, '')}"
       end
     end
   end


### PR DESCRIPTION
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->
This PR adds regional support to the method, as well as allowing the kuebclient gem to be used in govcloud
All of this code is available from the main branch and was added in the following PRs:
- https://github.com/ManageIQ/kubeclient/pull/630
- https://github.com/ManageIQ/kubeclient/pull/528
- https://github.com/ManageIQ/kubeclient/pull/507

Without these (old) changes, the currently released gem is unusable.
Some of these changes were added before the v5 cutoff started, but never got released

Fixes: #527

Changes tested in our account - currently patching a copy of this file into our Docker build, overwriting the latest release

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
