### PR TITLE
Try bumping recursive-open-struct

### DIFF
--- a/kubeclient.gemspec
+++ b/kubeclient.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 1.1', '< 3.0'
   spec.add_dependency 'faraday-follow_redirects', '>= 0.3.0'
-  spec.add_dependency 'recursive-open-struct', '~> 1.1', '>= 1.1.1'
+  spec.add_dependency 'recursive-open-struct', '>= 1.1.1', '< 3.0'
   spec.add_dependency 'http', '>= 3.0', '< 6.0'
 end


### PR DESCRIPTION
recursive-open-struct recently had a 2.0 release which included an ABI breaking change.  I'm not sure if the change affects kubeclient or not.  If not, it would be nice to be able to use the newer release.

I have only tried import test, I was hoping that c-i would give a better sniff.

https://github.com/wolfi-dev/os/issues/31938
