### PR TITLE
Update Ruby versions for CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os_and_command.os }}
     strategy:
       matrix:
-        ruby: [ '2.7', '3.0', '3.1', '3.2', 'ruby-head', 'truffleruby-head' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', 'ruby-head', 'truffleruby-head' ]
         gemfile: ["test/gemfiles/Gemfile.faraday-1", "test/gemfiles/Gemfile.faraday-2"]
         os_and_command:
         - os: 'macos-latest'
@@ -25,7 +25,7 @@ jobs:
           command: 'timeout --signal=TERM 3m env TESTOPTS="--verbose" test/config/update_certs_k0s.rb'
         include:
         # run rubocop against lowest supported ruby
-        - ruby: '2.7'
+        - ruby: '3.1'
           gemfile: 'Gemfile'
           os_and_command:
             os: ubuntu-latest


### PR DESCRIPTION
The Ruby versions for the GitHub Actions jobs have been updated to all currently maintained versions of Ruby.